### PR TITLE
Fix: pattern handling for properties

### DIFF
--- a/reflekt/property.py
+++ b/reflekt/property.py
@@ -7,7 +7,6 @@
 import re
 
 from cerberus import Validator
-
 from reflekt.casing import CAMEL_CASE_RE, SNAKE_CASE_RE, TITLE_CASE_RE
 from reflekt.errors import ReflektValidationError
 from reflekt.project import ReflektProject
@@ -32,6 +31,7 @@ class ReflektProperty(object):
             self.required = self._property_yaml.get("required", False)
             self.allow_null = self._property_yaml.get("allow_null", False)
             self.enum = self._property_yaml.get("enum")
+            self.pattern = self._property_yaml.get("pattern")
             self.datetime = self._property_yaml.get("datetime")
             self.array_item_schema = self._property_yaml.get("array_item_schema")
             self.object_properties = self._property_yaml.get("object_properties")


### PR DESCRIPTION
Reflekt wasn't sending property `pattern:` config to Segment Protocols.