### PR TITLE
Fix: raise Systemexit(1) correctly on error

### DIFF
--- a/reflekt/config.py
+++ b/reflekt/config.py
@@ -42,7 +42,7 @@ class ReflektConfig:
                 f" See the Reflekt docs (https://bit.ly/reflekt-profile-config) on "
                 f"profile configuration."
             )
-            SystemExit(1)
+            raise SystemExit(1)
 
     def _get_warehouse_type(self) -> str:
         if len(self.warehouse.keys()) > 1:
@@ -52,7 +52,7 @@ class ReflektConfig:
                 f"one warehouse can be defined per profile. See the Reflekt docs "
                 f"(https://bit.ly/reflekt-profile-config) on profile configuration."
             )
-            SystemExit(1)
+            raise SystemExit(1)
 
         warehouse_type: str = list(self.warehouse.keys())[0]
 
@@ -61,6 +61,6 @@ class ReflektConfig:
                 f"Unknown warehouse '{warehouse_type}' specified in reflekt_config.yml "
                 f"at {self.path}. Valid warehouses: {WAREHOUSES}"
             )
-            SystemExit(1)
+            raise SystemExit(1)
 
         return warehouse_type

--- a/reflekt/event.py
+++ b/reflekt/event.py
@@ -48,7 +48,7 @@ class ReflektEvent(object):
                     f"\n\nSee the Reflekt docs (bit.ly/reflekt-event-metadata) on "
                     f"metadata configuration."
                 )
-                SystemExit(1)
+                raise SystemExit(1)
 
     def _check_event_name_case(self) -> None:
         case_rule: str = self._project.events_case


### PR DESCRIPTION
Fixes bug where `SystemExit(1)` was not executing because preceding `raise` was missing.