### PR TITLE
Fix: Allow object properties in nested property

### DIFF
--- a/reflekt/cli.py
+++ b/reflekt/cli.py
@@ -747,16 +747,14 @@ if __name__ == "__main__":
     # new(["--project-dir", "test-plan"])
     # pull(["--name", "my-plan"])
     # push(["--name", "my-plan"])
-    # test(
-    #     [
-    #         "--name",
-    #         "test-plan",
-    #         "-e",
-    #         "cart-viewed",
-    #         "-e",
-    #         "product-added",
-    #     ]
-    # )
+    test(
+        [
+            "--name",
+            "surfline-web",
+            "-e",
+            "order-completed",
+        ]
+    )
     # dbt(
     #     [
     #         "--name",
@@ -773,4 +771,4 @@ if __name__ == "__main__":
     # pull(["--name", "tracking-plan-example"])
     # push(["--name", "tracking-plan-example"])
     # test(["--name", "tracking-plan-example"])
-    push(["--name", "tracking-plan-example", "--dev"])
+    # push(["--name", "tracking-plan-example", "--dev"])

--- a/reflekt/schema.py
+++ b/reflekt/schema.py
@@ -49,6 +49,8 @@ if reflekt_project.exists:
         "enum": {"required": False, "type": "list"},
         "pattern": {"required": False, "type": "string"},
         "datetime": {"required": False, "type": "boolean"},
+        "object_properties": {"required": False, "type": "list"},
+        "array_item_schema": {"required": False, "type": "list"},
     }
 
     reflekt_nested_property_schema = {


### PR DESCRIPTION
This enables a schema like:
```yaml
- version: 1
  name: Order Completed
  description: Server-side event fired when a user completes an order of
    any kind (subscription [free-trial or direct], ecommerce, travel, etc).
  metadata:
    fires_on: server
    owner: '@Surfline/squad-subscription'
    priority: 1
  properties:
    - name: orderId
      description: The ID of the order.
      type: string
      required: true
    - name: orderType
      description: The line of business the order takes place under (e.g.
        E-commerce, subscription, etc).
      type: string
      required: true
      enum:
        - ecommerce
        - subscription
        - travel
    - name: products
      description: Products in the order.
      type: array
      required: true
      array_item_schema:
        - name: variant
          description: 'A dictionary of key-value pairs describing the product
            (e.g. {color: ''blue'', size: ''large''}).'
          type: object
          object_properties:  # THIS IS NOW SUPPORTED
            - name: size
              description: The product size.
              type: string
            - name: color
              description: The product color.
              type: string
        ...
        ...
        ...
```