### PR TITLE
Feat: Add `reflekt push ... --update` and `reflekt push ... --remove` functionality

### DIFF
--- a/reflekt/api_handler.py
+++ b/reflekt/api_handler.py
@@ -23,8 +23,6 @@ class ReflektApiHandler:
             return AvoCli(  # Not CLI (not API), but called via get_api for consistency
                 avo_branch
             )
-        elif self._config.plan_type == "iteratively":
-            pass
         elif self._config.plan_type == "rudderstack":
             pass
         elif self._config.plan_type == "segment":

--- a/reflekt/cli.py
+++ b/reflekt/cli.py
@@ -145,8 +145,6 @@ def init(project_dir_str: str) -> None:
         #     pass
         # elif plan_type == "snowplow":
         #     pass
-        # elif plan_type == "iteratively":
-        #     pass
 
         cdp_num_prompt = click.prompt(
             f"How do you collect first-party data?"
@@ -359,8 +357,6 @@ def pull(plan_name: str, raw: bool, avo_branch: str) -> None:
         elif api.type.lower() == "segment":
             plan = SegmentPlan(plan_json)
         # TODO: Add support for other tracking plan types
-        # elif config.plan_type.lower() == "iteratively":
-        #     plan = IterativelyPlan(plan_json)
         # elif config.plan_type.lower() == "rudderstack":
         #     plan = RudderstackPlan(plan_json)
         # elif config.plan_type.lower() == "snowplow":
@@ -425,7 +421,7 @@ def push(plan_name, dry, dev, update_events, remove_events) -> None:
     api = ReflektApiHandler().get_api()
     config = ReflektConfig()
 
-    if api.type.lower() in ["avo", "iteratively"]:
+    if api.type.lower() in ["avo"]:
         logger.error(f"'reflekt push' not supported for {titleize(api.type)}.")
         raise click.Abort()
 
@@ -652,8 +648,6 @@ def dbt(
     pkg_name = f"reflekt_{project_name}_{cdp}"
     project_dir / "dbt-packages" / pkg_name
     dbt_project_yml = project.project_dir / "dbt_project.yml"
-    # blank_pkg_template = pkg_resources.resource_filename("reflekt", "templates/dbt/")
-    # tmp_pkg_dir = project_dir / ".reflekt" / "tmp" / pkg_name
     config.warehouse_type
 
     # Determine dbt pkg version to pass to ReflektTransformer

--- a/reflekt/constants.py
+++ b/reflekt/constants.py
@@ -24,7 +24,6 @@ PLANS = [
     "avo",
     # "rudderstack",
     # "snowplow",
-    # "iteratively",
 ]
 
 PLAN_INIT_STRING = (
@@ -32,7 +31,6 @@ PLAN_INIT_STRING = (
     "\n[2] Avo"
     # "\n[3] Rudderstack"
     # "\n[4] Snowplow"
-    # "\n[5] Iteratively"
 )
 
 PLAN_MAP = {
@@ -40,7 +38,6 @@ PLAN_MAP = {
     "2": "avo",
     # "3": "rudderstack",
     # "4": "snowplow",
-    # "5": "iteratively",
 }
 
 CDPS = [

--- a/reflekt/iteratively/__init__.py
+++ b/reflekt/iteratively/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2022 Gregory Clunies <greg@reflekt-ci.com>
-#
-# SPDX-License-Identifier: Apache-2.0

--- a/reflekt/iteratively/api.py
+++ b/reflekt/iteratively/api.py
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2022 Gregory Clunies <greg@reflekt-ci.com>
-#
-# SPDX-License-Identifier: Apache-2.0
-class IterativelyApi:
-    pass

--- a/reflekt/transformer.py
+++ b/reflekt/transformer.py
@@ -99,7 +99,7 @@ class ReflektTransformer(object):
             return self._build_plan_segment(self.reflekt_plan)
         elif plan_type.lower() == "snowplow":
             return self._build_plan_snowplow(self.reflekt_plan)
-        # 'reflekt push' not supported for Avo or Iteratively.
+        # 'reflekt push' not supported for Avo.
 
     def _build_plan_rudderstack(self):
         pass


### PR DESCRIPTION
This PR:
- ADDS:
  - `reflekt push -n plan-name --update event-name` to update/add a single events to a Segment tracking plan.
  - `reflekt push -n plan-name --remove event-name` to remove a single event from a Segment tracking plan.
- DEPRECATES
  - `reflekt push -n plan-name --dev` ... the `dev` flag was not found to produce a nice workflow.