### PR TITLE
Fix: handle nested enum, pattern, allow_null, etc when syncing to Segment Protocols

### DIFF
--- a/reflekt/cli.py
+++ b/reflekt/cli.py
@@ -869,7 +869,8 @@ if __name__ == "__main__":
         [
             "--name",
             "tracking-plan-example-dev",
-            "-r",
-            "test-event-four",
+            "-u",
+            "test-event-two",
+            "--dry",
         ]
     )

--- a/reflekt/cli.py
+++ b/reflekt/cli.py
@@ -869,8 +869,8 @@ if __name__ == "__main__":
         [
             "--name",
             "tracking-plan-example-dev",
-            "-u",
-            "test-event-two",
+            # "-u",
+            # "test-event-four",
             "--dry",
         ]
     )

--- a/reflekt/event.py
+++ b/reflekt/event.py
@@ -28,7 +28,7 @@ class ReflektEvent(object):
             self.name: str = self._event_yaml_obj.get("name")
             self.description: str = self._event_yaml_obj.get("description")
             self.metadata: dict = self._event_yaml_obj.get("metadata")
-            self.properties: list = [
+            self.properties: list[ReflektProperty] = [
                 ReflektProperty(property)
                 for property in self._event_yaml_obj["properties"]
             ]

--- a/reflekt/segment/schema.py
+++ b/reflekt/segment/schema.py
@@ -81,11 +81,3 @@ segment_property_schema = {
     "description": "",
     "type": "",
 }
-
-segment_items_schema = {
-    "items": {
-        "type": "object",
-        "properties": {},
-        "required": [],
-    }
-}

--- a/reflekt/transformer.py
+++ b/reflekt/transformer.py
@@ -37,7 +37,6 @@ from reflekt.segment.columns import (
 )
 from reflekt.segment.schema import (
     segment_event_schema,
-    segment_items_schema,
     segment_payload_schema,
     segment_plan_schema,
     segment_property_schema,
@@ -180,7 +179,9 @@ class ReflektTransformer(object):
 
         return segment_event
 
-    def _build_segment_property(self, reflekt_property: ReflektProperty) -> dict:
+    def _build_segment_property(
+        self, reflekt_property: Union[ReflektProperty, ReflektTrait]
+    ) -> dict:
         # If self._build_segment_property() is called recursively to build array or
         # object properties, need to convert the array_item_schema or object_properties
         # attribute, which is a dict, to a ReflektProperty

--- a/reflekt/transformer.py
+++ b/reflekt/transformer.py
@@ -218,50 +218,60 @@ class ReflektTransformer(object):
             hasattr(reflekt_property, "array_item_schema")
             and reflekt_property.array_item_schema is not None
         ):
-            segment_array_items = copy.deepcopy(segment_items_schema)
-            for reflekt_item_property in reflekt_property.array_item_schema:
-                segment_item_property = copy.deepcopy(segment_property_schema)
-                segment_item_property["description"] = reflekt_item_property[
-                    "description"
-                ]
-                segment_item_property["type"] = [reflekt_item_property["type"]]
-                segment_item_property = self._parse_reflekt_property(
-                    reflekt_item_property, segment_item_property
-                )
-
-                if (
-                    "required" in reflekt_item_property
-                    and reflekt_item_property["required"]
-                ):
-                    segment_array_items["items"]["required"].append(
-                        reflekt_item_property["name"]
-                    )
-
-                segment_array_items["items"]["properties"].update(
-                    {reflekt_item_property["name"]: segment_item_property}
-                )
-
-            updated_segment_property.update(segment_array_items)
+            self._parse_array_items(
+                reflekt_property.array_item_schema, updated_segment_property
+            )
 
         if (
             hasattr(reflekt_property, "object_properties")
             and reflekt_property.object_properties is not None
         ):
-            updated_segment_property["properties"] = {}
-            updated_segment_property["required"] = []
-
-            for object_property in reflekt_property.object_properties:
-                segment_property = copy.deepcopy(segment_property_schema)
-                segment_property["description"] = object_property["description"]
-                segment_property["type"] = object_property["type"]
-                updated_segment_property["properties"].update(
-                    {object_property["name"]: segment_property}
-                )
-
-                if "required" in object_property and object_property["required"]:
-                    updated_segment_property["required"].append(object_property["name"])
+            self._parse_object_properties(
+                reflekt_property.object_properties, updated_segment_property
+            )
 
         return updated_segment_property
+
+    def _parse_array_items(self, reflekt_array_item_schema, updated_segment_property):
+        segment_array_items = copy.deepcopy(segment_items_schema)
+        for array_item_property in reflekt_array_item_schema:
+            segment_item_property = copy.deepcopy(segment_property_schema)
+            segment_item_property["description"] = array_item_property["description"]
+            segment_item_property["type"] = [array_item_property["type"]]
+            segment_item_property = self._parse_reflekt_property(
+                array_item_property, segment_item_property
+            )
+
+            segment_array_items["items"]["properties"].update(
+                {array_item_property["name"]: segment_item_property}
+            )
+            updated_segment_property.update(segment_array_items)
+
+            if "required" in array_item_property and array_item_property["required"]:
+                segment_array_items["items"]["required"].append(
+                    array_item_property["name"]
+                )
+
+    def _parse_object_properties(
+        self, reflekt_property_object_properties, updated_segment_property
+    ):
+        updated_segment_property["properties"] = {}
+        updated_segment_property["required"] = []
+
+        for object_property in reflekt_property_object_properties:
+            segment_object_property = copy.deepcopy(segment_property_schema)
+            segment_object_property["description"] = object_property["description"]
+            segment_object_property["type"] = object_property["type"]
+            segment_object_property = self._parse_reflekt_property(
+                object_property, segment_object_property
+            )
+
+            updated_segment_property["properties"].update(
+                {object_property["name"]: segment_object_property}
+            )
+
+            if "required" in object_property and object_property["required"]:
+                updated_segment_property["required"].append(object_property["name"])
 
     def _build_segment_trait(self, reflekt_trait: ReflektTrait) -> dict:
         segment_trait = copy.deepcopy(segment_property_schema)

--- a/tests/test_reflekt_loader.py
+++ b/tests/test_reflekt_loader.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import yaml
+
 from reflekt.event import ReflektEvent
 from reflekt.loader import ReflektLoader
 from reflekt.plan import ReflektPlan
-
 from tests.build import build_reflekt_plan_dir
 from tests.fixtures.reflekt_event import REFLEKT_EVENT
 from tests.fixtures.reflekt_plan import REFLEKT_PLAN

--- a/tests/test_reflekt_transformer.py
+++ b/tests/test_reflekt_transformer.py
@@ -5,7 +5,6 @@
 
 from reflekt.loader import ReflektLoader
 from reflekt.transformer import ReflektTransformer
-
 from tests.build import build_reflekt_plan_dir
 
 

--- a/tests/test_reflekt_transformer.py
+++ b/tests/test_reflekt_transformer.py
@@ -5,6 +5,7 @@
 
 from reflekt.loader import ReflektLoader
 from reflekt.transformer import ReflektTransformer
+
 from tests.build import build_reflekt_plan_dir
 
 
@@ -108,20 +109,18 @@ def test_reflekt_transformer_segment(tmpdir):
         ]
         == "The 1st key in the object dictionary."
     )
-    assert (
-        segment_plan_event_props["property_seven"]["properties"]["key_one"]["type"]
-        == "string"
-    )
+    assert segment_plan_event_props["property_seven"]["properties"]["key_one"][
+        "type"
+    ] == ["string"]
     assert (
         segment_plan_event_props["property_seven"]["properties"]["key_two"][
             "description"
         ]
         == "The 2nd key in the object dictionary."
     )
-    assert (
-        segment_plan_event_props["property_seven"]["properties"]["key_two"]["type"]
-        == "number"
-    )
+    assert segment_plan_event_props["property_seven"]["properties"]["key_two"][
+        "type"
+    ] == ["number"]
     assert (
         segment_plan_event_props["property_eight"]["description"]
         == "A date-time property."


### PR DESCRIPTION
Fixes a bug where nested properties (in `array_item_shema` or `object_propeties`) were not correctly syncing to Segment Protocols.