### PR TITLE
Feat: `reflekt pull` uses Avo Export API

### DIFF
--- a/reflekt/api_handler.py
+++ b/reflekt/api_handler.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional
+from loguru import logger
 
-from reflekt.avo.cli import AvoCli
+from reflekt.avo.api import AvoApi
 from reflekt.config import ReflektConfig
+from reflekt.constants import PLANS
+from reflekt.project import ReflektProject
 from reflekt.segment.api import SegmentApi
 
 
@@ -15,20 +17,32 @@ class ReflektApiHandler:
     """
 
     def __init__(self) -> None:
+        self._project = ReflektProject()
         self._config = ReflektConfig()
         self.type: str = self._config.plan_type
 
-    def get_api(self, avo_branch: Optional[str] = None):
-        if self._config.plan_type == "avo":
-            return AvoCli(  # Not CLI (not API), but called via get_api for consistency
-                avo_branch
-            )
-        elif self._config.plan_type == "rudderstack":
-            pass
-        elif self._config.plan_type == "segment":
+    def get_api(self):
+        if self._config.plan_type == "segment":
             return SegmentApi(
                 workspace_name=self._config.workspace_name,
                 access_token=self._config.access_token,
             )
-        elif self._config.plan_type == "snowplow":
-            pass
+        elif self._config.plan_type == "avo":
+            return AvoApi(
+                # TODO
+                # 1. Add to Avo config profile
+                # 2. Update reflekt init to prompt user for service account credentials
+                workspace_id=self._config.workspace_id,
+                service_account_name=self._config.service_account_name,
+                service_account_secret=self._config.service_account_secret,
+            )
+        # elif self._config.plan_type == "rudderstack":
+        #     pass
+        # elif self._config.plan_type == "snowplow":
+        #     pass
+        else:
+            logger.error(
+                f"Tracking plan type '{self._config.plan_type}' defined in "
+                f"{self._config.path} is not supported by Reflekt. Supported tracking "
+                f"plan types are: {PLANS}"
+            )

--- a/reflekt/avo/api.py
+++ b/reflekt/avo/api.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2022 Gregory Clunies <greg@reflekt-ci.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional
+
+import requests
+from loguru import logger
+from reflekt.project import ReflektProject
+from requests.auth import HTTPBasicAuth
+
+
+class AvoApi:
+    def __init__(
+        self,
+        workspace_id: str,
+        service_account_name: str,
+        service_account_secret: str,
+    ) -> None:
+        self.type = "avo"
+        self.workspace_id = workspace_id
+        self.service_account_name = service_account_name
+        self.service_account_secret = service_account_secret
+        self.base_url = f"https://api.avo.app/workspaces/{workspace_id}/"
+
+    def _get_avo_branch_id(self, avo_branch: Optional[str] = None):
+        if avo_branch is None or avo_branch == "main":
+            branch_id = "main"
+        else:
+            try:
+                branch_id = ReflektProject().tracking_plans["avo"]["branches"][
+                    avo_branch
+                ]
+            except KeyError:
+                logger.error(
+                    f"Avo branch '{avo_branch}' not defined in reflekt_project.yml. "
+                    f"See Reflekt docs (https://bit.ly/reflekt-project-config) for "
+                    f"details on Avo tracking plan and branch configuration."
+                )
+                raise SystemExit(1)
+
+        return branch_id
+
+    def get(self, avo_branch: str) -> None:
+        branch_id = self._get_avo_branch_id(avo_branch)
+        url = self.base_url + f"branches/{branch_id}/export/v1"
+        r = requests.get(
+            url=url,
+            auth=HTTPBasicAuth(self.service_account_name, self.service_account_secret),
+        )
+
+        return r.json()

--- a/reflekt/config.py
+++ b/reflekt/config.py
@@ -26,8 +26,14 @@ class ReflektConfig:
             self.config: dict = self._get_config()
             self.plan_type: str = self.config.get("plan_type")
             self.cdp_name: str = self.config.get("cdp")
+            # Segment
             self.access_token: str = self.config.get("access_token")
             self.workspace_name: str = self.config.get("workspace_name")
+            # Avo
+            self.workspace_id: str = self.config.get("workspace_id")
+            self.service_account_name: str = self.config.get("service_account_name")
+            self.service_account_secret: str = self.config.get("service_account_secret")
+            # Warehouse
             self.warehouse: str = self.config.get("warehouse")
             self.warehouse_type: str = self._get_warehouse_type()
 

--- a/reflekt/project.py
+++ b/reflekt/project.py
@@ -42,12 +42,11 @@ class ReflektProject:
                 ],
             }
             logger.configure(**logger_config)
-
             self.project_yml = self.project_dir / "reflekt_project.yml"
             self.exists = True if self.project_yml.exists() else False
 
             with open(self.project_yml, "r") as f:
-                self.project = yaml.safe_load(f)
+                self.project: dict = yaml.safe_load(f)
 
             self.validate_project()
 
@@ -55,6 +54,7 @@ class ReflektProject:
         self._get_project_name()
         self._get_config_profile()
         self._get_config_path()
+        self._get_tracking_plans_obj()
         self._get_events_case()
         self._get_events_allow_numbers()
         self._get_events_reserved()
@@ -123,9 +123,9 @@ class ReflektProject:
             self.name = self.project["name"]
         except KeyError:
             logger.error(
-                "Project 'name:' config not defined in reflekt_project.yml. See Reflekt "
-                "docs for details on project name configuration: "
-                # noqa: E501
+                "Project 'name:' config not defined in reflekt_project.yml. "
+                "\n\nSee Reflekt docs (https://bit.ly/reflekt-project-config) "
+                "for details on project name configuration."
             )
             raise SystemExit(1)
 
@@ -134,9 +134,9 @@ class ReflektProject:
             self.config_profile = self.project["config_profile"]
         except KeyError:
             logger.error(
-                "No 'config_profile:' defined in reflekt_project.yml. See Reflekt "
-                "docs for details on 'config_profile:' configuration: "
-                # noqa: E501
+                "No 'config_profile:' defined in reflekt_project.yml. \n\nSee Reflekt "
+                "docs (https://bit.ly/reflekt-project-config) for details on "
+                "'config_profile:' configuration."
             )
             raise SystemExit(1)
 
@@ -148,19 +148,30 @@ class ReflektProject:
 
             if not self.config_path.exists():
                 logger.error(
-                    "The 'config_path: {str(self.config_path)}' defined in "
-                    "reflekt_project.yml does not exist."
+                    f"The 'config_path: {str(self.config_path)}' defined in "
+                    f"reflekt_project.yml does not exist."
                 )
                 raise SystemExit(1)
 
             if not self.config_path.is_absolute():
                 logger.error(
-                    "The 'config_path: {str(self.config_path)}' defined in "
-                    "reflekt_project.yml must be an absolute path."
+                    f"The 'config_path: {str(self.config_path)}' defined in "
+                    f"reflekt_project.yml must be an absolute path."
                 )
                 raise SystemExit(1)
         else:
             self.config_path = None
+
+    def _get_tracking_plans_obj(self) -> None:
+        try:
+            self.tracking_plans = self.project["tracking_plans"]
+        except KeyError:
+            logger.error(
+                "Missing 'tracking_plans:' config in reflekt_project.yml. \n\nSee the "
+                "Reflekt docs (https://bit.ly/reflekt-project-config) for details on "
+                "tracking plan configuration."
+            )
+            raise SystemExit(1)
 
     def _get_events_case(self) -> None:
         try:

--- a/reflekt/segment/api.py
+++ b/reflekt/segment/api.py
@@ -6,16 +6,13 @@ import json
 from typing import Optional
 
 import requests
-from requests import Response
-
-from reflekt.config import ReflektConfig
 from reflekt.segment.errors import SegmentApiError
+from requests import Response
 
 
 class SegmentApi:
     def __init__(self, workspace_name: str, access_token: str):
-        self._config = ReflektConfig()
-        self.type = self._config.plan_type
+        self.type = "segment"
         self.workspace_name = workspace_name
         self.access_token = access_token
         self.base_url = (


### PR DESCRIPTION
Reflekt now uses [Avo's Export API](https://www.avo.app/docs/public-api/export-tracking-plan) instead of the [Avo CLI](https://www.avo.app/docs/implementation/cli).