### PR TITLE
Fix: Segment std tables templating

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.15
+current_version = 0.2.16
 commit = False
 tag = False
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Setup env using:
-#    conda env update --file /Users/gclunies2-mba/Repos/Reflekt/environment.yml --prune
+# Setup for python env using conda:
+#   1. Install conda env with poetry dependency
+#         conda env update --file /Users/gclunies2-mba/Repos/Reflekt/environment.yml --prune
+#   2. Activate the conda env `source activate reflekt-conda` OR `conda activate reflekt-conda`
+#   3. Run `poetry install` ... this will install the dependencies from poetry.lock
+#      INSIDE the conda env (magic!)
 name: reflekt-conda
 channels:
 - conda-forge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "reflekt"
-version = "0.2.15"
+version = "0.2.16"
 description = "Reflekt lets data teams: 1) Define tracking plans as code; 2) Template dbt packages that model and document tracking plan events, ready for use in dbt."
 authors = ["Greg Clunies <greg.clunies@gmail.com>"]
 license = "Apache-2.0"

--- a/reflekt/__init__.py
+++ b/reflekt/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.2.15"  # Set by bumpversion
+__version__ = "0.2.16"  # Set by bumpversion

--- a/reflekt/transformer.py
+++ b/reflekt/transformer.py
@@ -343,47 +343,43 @@ class ReflektTransformer(object):
         dbt_src = self._template_dbt_source(reflekt_plan=reflekt_plan)
 
         std_segment_tables = []
-        if self.reflekt_plan.user_traits:
-            std_segment_tables.append(
-                {
-                    "name": "identifies",
-                    "description": "A table with identify() calls.",
-                    "unique_key": "identify_id",
-                    "cdp_cols": seg_identify_cols,
-                    "plan_cols": reflekt_plan.user_traits,
-                }
-            )
-            std_segment_tables.append(
-                {
-                    "name": "users",
-                    "description": "A table with the latest traits for users.",
-                    "unique_key": "user_id",
-                    "cdp_cols": seg_users_cols,
-                    "plan_cols": reflekt_plan.user_traits,
-                }
-            )
-
-        if self.reflekt_plan.group_traits:
-            std_segment_tables.append(
-                {
-                    "name": "groups",
-                    "description": "A table with group() calls.",
-                    "unique_key": "group_id",
-                    "cdp_cols": seg_groups_cols,
-                    "plan_cols": reflekt_plan.group_traits,
-                }
-            )
-
-        if self.reflekt_plan.events:
-            std_segment_tables.append(
-                {
-                    "name": "tracks",
-                    "description": "A table with event track() calls.",
-                    "unique_key": "event_id",
-                    "cdp_cols": seg_tracks_cols,
-                    "plan_cols": [],
-                }
-            )
+        # ALWAYS try to template standard tables. If they don't exist, Reflekt will skip
+        std_segment_tables.append(
+            {
+                "name": "identifies",
+                "description": "A table with identify() calls.",
+                "unique_key": "identify_id",
+                "cdp_cols": seg_identify_cols,
+                "plan_cols": reflekt_plan.user_traits,
+            }
+        )
+        std_segment_tables.append(
+            {
+                "name": "users",
+                "description": "A table with the latest traits for users.",
+                "unique_key": "user_id",
+                "cdp_cols": seg_users_cols,
+                "plan_cols": reflekt_plan.user_traits,
+            }
+        )
+        std_segment_tables.append(
+            {
+                "name": "groups",
+                "description": "A table with group() calls.",
+                "unique_key": "group_id",
+                "cdp_cols": seg_groups_cols,
+                "plan_cols": reflekt_plan.group_traits,
+            }
+        )
+        std_segment_tables.append(
+            {
+                "name": "tracks",
+                "description": "A table with event track() calls.",
+                "unique_key": "event_id",
+                "cdp_cols": seg_tracks_cols,
+                "plan_cols": [],
+            }
+        )
 
         for std_segment_table in std_segment_tables:
             db_columns, error_msg = self.db_engine.get_columns(


### PR DESCRIPTION
Fix issue where `identifies`, `users`, and `groups` table data were not templated by `reflekt dbt` when `user_traits.yml` / `group_traits.yml` were empty (i.e. `traits: []` ).