### PR TITLE
Feat: add `where_logic` config for `materialized: view`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.16
+current_version = 0.2.17
 commit = False
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "reflekt"
-version = "0.2.16"
+version = "0.2.17"
 description = "Reflekt lets data teams: 1) Define tracking plans as code; 2) Template dbt packages that model and document tracking plan events, ready for use in dbt."
 authors = ["Greg Clunies <greg.clunies@gmail.com>"]
 license = "Apache-2.0"

--- a/reflekt/__init__.py
+++ b/reflekt/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.2.16"  # Set by bumpversion
+__version__ = "0.2.17"  # Set by bumpversion

--- a/reflekt/avo/api.py
+++ b/reflekt/avo/api.py
@@ -6,8 +6,9 @@ from typing import Optional
 
 import requests
 from loguru import logger
-from reflekt.project import ReflektProject
 from requests.auth import HTTPBasicAuth
+
+from reflekt.project import ReflektProject
 
 
 class AvoApi:

--- a/reflekt/avo/plan.py
+++ b/reflekt/avo/plan.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import yaml
 from inflection import dasherize, underscore
 from loguru import logger
+
 from reflekt.avo.parser import parse_avo_event, parse_avo_property
 from reflekt.dumper import ReflektYamlDumper
 

--- a/reflekt/project.py
+++ b/reflekt/project.py
@@ -69,6 +69,7 @@ class ReflektProject:
         self._get_dbt_model_prefix()
         self._get_dbt_model_materialized()
         self._get_dbt_model_incremental_logic()
+        self._get_dbt_model_where_logic()
         self._get_dbt_docs_prefix()
         self._get_dbt_docs_tests()
         self._get_dbt_docs_in_folder()
@@ -377,6 +378,28 @@ class ReflektProject:
 
         else:
             self.incremental_logic = None
+
+    def _get_dbt_model_where_logic(self) -> None:
+        if self.materialized == "incremental":
+            if (
+                self.where_logic
+                == self.project["dbt"]["templater"]["models"].get("where_logic")
+                is not None
+            ):
+                logger.error(
+                    "dbt templating config 'materialized: incremental' is not "
+                    "compatible with 'where_logic: ...' config. Options: "
+                    "\n    1. Use 'materialized: incremental' + 'incremental_logic: ...' configurations"  # noqa: E501
+                    "\n    2. Use 'materialized: view' + 'where_logic: ...' configurations"  # noqa: E501
+                    "\n\nSee the Reflekt docs (https://bit.ly/reflekt-project-config) "
+                    "for details on materialization configuration."
+                )
+                raise SystemExit(1)
+            pass  #
+        elif self.materialized == "view":
+            self.where_logic = self.project["dbt"]["templater"]["models"].get(
+                "where_logic"
+            )
 
     def _get_dbt_docs_prefix(self) -> None:
         try:

--- a/reflekt/project.py
+++ b/reflekt/project.py
@@ -381,11 +381,7 @@ class ReflektProject:
 
     def _get_dbt_model_where_logic(self) -> None:
         if self.materialized == "incremental":
-            if (
-                self.where_logic
-                == self.project["dbt"]["templater"]["models"].get("where_logic")
-                is not None
-            ):
+            if self.project["dbt"]["templater"]["models"].get("where_logic") is not None:
                 logger.error(
                     "dbt templating config 'materialized: incremental' is not "
                     "compatible with 'where_logic: ...' config. Options: "

--- a/reflekt/segment/api.py
+++ b/reflekt/segment/api.py
@@ -6,8 +6,9 @@ import json
 from typing import Optional
 
 import requests
-from reflekt.segment.errors import SegmentApiError
 from requests import Response
+
+from reflekt.segment.errors import SegmentApiError
 
 
 class SegmentApi:

--- a/reflekt/segment/plan.py
+++ b/reflekt/segment/plan.py
@@ -20,6 +20,7 @@ import funcy
 import yaml
 from inflection import dasherize, underscore
 from loguru import logger
+
 from reflekt.dumper import ReflektYamlDumper
 from reflekt.segment.parser import parse_segment_event, parse_segment_property
 

--- a/reflekt/tracking.py
+++ b/reflekt/tracking.py
@@ -16,10 +16,10 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+import segment.analytics as segment_analytics  # FOR DEBUGGING, use 'import analytics as segment_analytics'  # noqa: E501
+
 # import rudder_analytics
 import yaml
-
-import segment.analytics as segment_analytics  # FOR DEBUGGING, use 'import analytics as segment_analytics'  # noqa: E501
 
 
 # Tracking error handling (Segment/Rudderstack)

--- a/reflekt/transformer.py
+++ b/reflekt/transformer.py
@@ -14,33 +14,22 @@ from loguru import logger
 from packaging.version import Version
 
 from reflekt.config import ReflektConfig
-from reflekt.constants import REFLEKT_INJECTED_COLUMNS, REFLEKT_TEMPLATED_COLUMNS
-from reflekt.dbt import (
-    dbt_column_schema,
-    dbt_doc_schema,
-    dbt_model_schema,
-    dbt_src_schema,
-    dbt_table_schema,
-)
+from reflekt.constants import (REFLEKT_INJECTED_COLUMNS,
+                               REFLEKT_TEMPLATED_COLUMNS)
+from reflekt.dbt import (dbt_column_schema, dbt_doc_schema, dbt_model_schema,
+                         dbt_src_schema, dbt_table_schema)
 from reflekt.dumper import ReflektYamlDumper
 from reflekt.event import ReflektEvent
 from reflekt.plan import ReflektPlan
 from reflekt.project import ReflektProject
 from reflekt.property import ReflektProperty
-from reflekt.segment.columns import (
-    seg_groups_cols,
-    seg_identify_cols,
-    seg_pages_cols,
-    seg_screens_cols,
-    seg_tracks_cols,
-    seg_users_cols,
-)
-from reflekt.segment.schema import (
-    segment_event_schema,
-    segment_payload_schema,
-    segment_plan_schema,
-    segment_property_schema,
-)
+from reflekt.segment.columns import (seg_groups_cols, seg_identify_cols,
+                                     seg_pages_cols, seg_screens_cols,
+                                     seg_tracks_cols, seg_users_cols)
+from reflekt.segment.schema import (segment_event_schema,
+                                    segment_payload_schema,
+                                    segment_plan_schema,
+                                    segment_property_schema)
 from reflekt.trait import ReflektTrait
 from reflekt.utils import segment_2_snake
 from reflekt.warehouse import WarehouseConnection
@@ -770,9 +759,9 @@ class ReflektTransformer(object):
     ) -> str:
         if incremental_logic is None and where_logic is None:
             logic = ""
-        elif incremental_logic and where_logic is None:
+        elif incremental_logic is not None and where_logic is None:
             logic = incremental_logic
-        elif where_logic and incremental_logic is None:
+        elif where_logic is not None and incremental_logic is None:
             logic = where_logic
         else:  # Both logics exist (error)
             logger.error(

--- a/reflekt/transformer.py
+++ b/reflekt/transformer.py
@@ -14,22 +14,33 @@ from loguru import logger
 from packaging.version import Version
 
 from reflekt.config import ReflektConfig
-from reflekt.constants import (REFLEKT_INJECTED_COLUMNS,
-                               REFLEKT_TEMPLATED_COLUMNS)
-from reflekt.dbt import (dbt_column_schema, dbt_doc_schema, dbt_model_schema,
-                         dbt_src_schema, dbt_table_schema)
+from reflekt.constants import REFLEKT_INJECTED_COLUMNS, REFLEKT_TEMPLATED_COLUMNS
+from reflekt.dbt import (
+    dbt_column_schema,
+    dbt_doc_schema,
+    dbt_model_schema,
+    dbt_src_schema,
+    dbt_table_schema,
+)
 from reflekt.dumper import ReflektYamlDumper
 from reflekt.event import ReflektEvent
 from reflekt.plan import ReflektPlan
 from reflekt.project import ReflektProject
 from reflekt.property import ReflektProperty
-from reflekt.segment.columns import (seg_groups_cols, seg_identify_cols,
-                                     seg_pages_cols, seg_screens_cols,
-                                     seg_tracks_cols, seg_users_cols)
-from reflekt.segment.schema import (segment_event_schema,
-                                    segment_payload_schema,
-                                    segment_plan_schema,
-                                    segment_property_schema)
+from reflekt.segment.columns import (
+    seg_groups_cols,
+    seg_identify_cols,
+    seg_pages_cols,
+    seg_screens_cols,
+    seg_tracks_cols,
+    seg_users_cols,
+)
+from reflekt.segment.schema import (
+    segment_event_schema,
+    segment_payload_schema,
+    segment_plan_schema,
+    segment_property_schema,
+)
 from reflekt.trait import ReflektTrait
 from reflekt.utils import segment_2_snake
 from reflekt.warehouse import WarehouseConnection

--- a/tests/test_reflekt_loader.py
+++ b/tests/test_reflekt_loader.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import yaml
+
 from reflekt.event import ReflektEvent
 from reflekt.loader import ReflektLoader
 from reflekt.plan import ReflektPlan
-
 from tests.build import build_reflekt_plan_dir
 from tests.fixtures.reflekt_event import REFLEKT_EVENT
 from tests.fixtures.reflekt_plan import REFLEKT_PLAN

--- a/tests/test_reflekt_transformer.py
+++ b/tests/test_reflekt_transformer.py
@@ -5,7 +5,6 @@
 
 from reflekt.loader import ReflektLoader
 from reflekt.transformer import ReflektTransformer
-
 from tests.build import build_reflekt_plan_dir
 
 


### PR DESCRIPTION
Allow user to set `where_logic:` to be used with `materialized: view` in `reflekt_project.yml` configuration.
```yaml
dbt:
  templater:
    models:
      prefix: stg_        # Prefix for models in templated dbt package
      materialized: view  # view|incremental
      # OPTIONAL `where_logic` for staging model templating. Useful to limit data in dev
      where_logic: |
        {%- if target.name == 'dev' -%}
        where received_at >= {{ var('dev_start_date') }}
        {%- endif -%}
```

which will result in the following SQL for templated staging models
```sql
{{
  config(
    materialized = 'view',
  )
}}

with

source as (

    select *

    from {{ source('surfline_android', 'application_installed') }}
    {%- if target.name == 'dev' -%}
    where received_at >= {{ var('dev_start_date') }}
    {%- endif -%}

),

renamed as (
    ...
)

select * from renamed
```