### PR TITLE
Fix: Do not apply `incremental_logic` or `where_logic` for users/groups tables when templating

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.17
+current_version = 0.2.18
 commit = False
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "reflekt"
-version = "0.2.17"
+version = "0.2.18"
 description = "Reflekt lets data teams: 1) Define tracking plans as code; 2) Template dbt packages that model and document tracking plan events, ready for use in dbt."
 authors = ["Greg Clunies <greg.clunies@gmail.com>"]
 license = "Apache-2.0"

--- a/reflekt/__init__.py
+++ b/reflekt/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.2.17"  # Set by bumpversion
+__version__ = "0.2.18"  # Set by bumpversion

--- a/reflekt/transformer.py
+++ b/reflekt/transformer.py
@@ -768,7 +768,9 @@ class ReflektTransformer(object):
         incremental_logic: Optional[str] = None,
         where_logic: Optional[str] = None,
     ) -> str:
-        if incremental_logic is None and where_logic is None:
+        if source_table in ["users", "groups"]:  # These tables are dimensions, not facts
+            logic = ""
+        elif incremental_logic is None and where_logic is None:
             logic = ""
         elif incremental_logic is not None and where_logic is None:
             logic = incremental_logic


### PR DESCRIPTION
We do not want to apply `incremental_logic` or `where_logic` configs from `reflekt_project.yml` when templating users or groups data.