### PR TITLE
`reflekt init` improvements & tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # poetry
-# source ./.venv/bin/activate
-# unset PS1
+source ./.venv/bin/activate
+unset PS1
 
 # conda
-source activate reflekt-conda
+# source activate reflekt-conda

--- a/reflekt/profile.py
+++ b/reflekt/profile.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 import pkgutil
 from pathlib import Path
 from typing import List, Optional
@@ -37,6 +38,7 @@ class Profile:
         """
         self.project: Project = project
         self.path: Path = project.profiles_path
+        self.dir = self.path.parent
 
         if profile_name is not None:
             self.name: str = profile_name
@@ -92,13 +94,23 @@ class Profile:
             with self.path.open() as f:
                 profiles = yaml.safe_load(f)
 
-            profile = {
-                self.name: {
-                    "registry": self.registry,
-                    "source": self.source,
-                },
-            }
-            profiles.update(profile)
+            if self.do_not_track:
+                profile = {
+                    self.name: {
+                        "do_not_track": self.do_not_track,
+                        "registry": self.registry,
+                        "source": self.source,
+                    },
+                }
+            else:
+                profile = {
+                    self.name: {
+                        "registry": self.registry,
+                        "source": self.source,
+                    },
+                }
+
+            profiles.update(profile)  # Add profile to profiles dict
 
         else:
             profiles = {
@@ -108,6 +120,10 @@ class Profile:
                     "source": self.source,
                 },
             }
+
+        # Check that that profile directory exists
+        if not self.dir.exists():
+            os.makedirs(self.dir)
 
         with self.path.open("w") as f:
             yaml.dump(

--- a/reflekt/project.py
+++ b/reflekt/project.py
@@ -156,6 +156,10 @@ class Project:
                 "artifacts": self.artifacts,
             }
 
+        # Check that that project directory exists
+        if not self.dir.exists():
+            os.makedirs(self.dir)
+
         with self.path.open("w") as f:
             yaml.dump(
                 data,

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -44,6 +44,50 @@ def test_profile():
     }
 
 
+def test_profile_to_yaml():
+    """Test that profile can be written to yaml."""
+    project = Project(use_defaults=False, path="./tests/fixtures/reflekt_project.yml")
+    profile = Profile(project=project)
+    profile.path = Path("./tests/fixtures/tmp_reflekt_profiles.yml").resolve()
+    profile.to_yaml()
+
+    # Read tmp_reflekt_profiles.yml
+    with profile.path.open() as f:
+        profile_yml = yaml.safe_load(f)
+
+    # NOTE - do_not_track is not written to yaml if False
+    assert profile_yml == {
+        "version": 1.0,
+        "test_profile": {
+            "registry": [
+                {
+                    "type": "segment",
+                    "api_token": "test_token",
+                },
+                {
+                    "type": "avo",
+                    "workspace_id": "test_workspace_id",
+                    "service_account_name": "test_service_account_name",
+                    "service_account_secret": "test_secret",
+                },
+            ],
+            "source": [
+                {
+                    "id": "test_source",
+                    "type": "snowflake",
+                    "account": "test_account",
+                    "database": "test_database",
+                    "warehouse": "test_warehouse",
+                    "role": "test_role",
+                    "user": "test_user",
+                    "password": "test_password",
+                }
+            ],
+        },
+    }
+    profile.path.unlink(missing_ok=True)  # Cleanup
+
+
 def test_non_existent_profiles_path():
     """Test that a non-existent profile errors."""
     project = Project(path="./tests/fixtures/reflekt_project.yml")


### PR DESCRIPTION
Adds:
1. Logic to ensure `profiles.yml` file is created during the `reflekt init` command, creating and required upstream directories as defined by the user's prompt response.
2. Fix a bug in `Profiles` class where the `profiles` dict was not guaranteed to exist before executing `profiles.update()`.

Fixes #86 and #87.