### PR TITLE
Fix: `reflekt pull` handles blank event description in segment protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ SPDX-License-Identifier: Apache-2.0
 
 # Reflekt Changelog
 
-## [0.5.0] - 2023-10
+## [0.5.0] - 2023-12-31
 ### Breaking
-- Only support python versions `>=3.9,<3.13`. Support for pyhton `3.8` is DEPRECATED.
+- Only support python versions `>=3.9,<3.13`. Support for python `3.8` is DEPRECATED.
 
+### Added
+- Add [jaffle_shop_sessions.py](scripts/jaffle_shop/jaffle_shop_sessions.py) script to create example events and user [session data](data/jaffle_shop_sessions.csv).
+
+## Fixed
+- [#99](https://github.com/GClunies/Reflekt/issues/99) which caused an error when pulling events without an event description from Segment protocols.
 
 ## [0.4.0] - 2023-10
 ### Added

--- a/reflekt/registry/segment.py
+++ b/reflekt/registry/segment.py
@@ -375,7 +375,7 @@ class SegmentRegistry:
                 )
             elif s_schema["type"] == "TRACK":
                 name = s_schema["key"]
-                description = s_schema["jsonSchema"]["description"]
+                description = s_schema["jsonSchema"].get("description", "")
                 metadata = s_schema["jsonSchema"].get("labels", {})
                 properties = (
                     s_schema["jsonSchema"]


### PR DESCRIPTION
Addresses #99.